### PR TITLE
feat: Throw an error in CI

### DIFF
--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -75,6 +75,10 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
 
       <alert>Consider not enabling this if you are using TailwindCSS, as prettier will struggle to cope with parsing the size of your HTML in development mode.</alert>
 
+   - `failOnError` will make the command ` nuxt generate` failing if an error is met.
+
+      <alert>Useful in Continuous Integration.</alert>
+
    - `options` allows you to pass in `html-validate` options that will be merged with the default configuration
 
       <alert type="info">You can find more about configuring `html-validate` [here](https://html-validate.org/rules/index.html).</alert>
@@ -85,6 +89,7 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
    {
      htmlValidator: {
        usePrettier: false,
+       failOnError: false,
        options: {
          extends: [
            'html-validate:document',

--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -75,7 +75,7 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
 
       <alert>Consider not enabling this if you are using TailwindCSS, as prettier will struggle to cope with parsing the size of your HTML in development mode.</alert>
 
-   - `failOnError` will make the command ` nuxt generate` failing if an error is met.
+   - `failOnError` will make the command ` nuxt generate` failing if an error is met. 
 
       <alert>Useful in Continuous Integration.</alert>
 

--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -75,9 +75,9 @@ This module configures [`html-validate`](https://html-validate.org/) to automati
 
       <alert>Consider not enabling this if you are using TailwindCSS, as prettier will struggle to cope with parsing the size of your HTML in development mode.</alert>
 
-   - `failOnError` will make the command ` nuxt generate` failing if an error is met. 
+   - `failOnError` will throw an error after running `nuxt generate` if there are any validation errors with the generated pages.
 
-      <alert>Useful in Continuous Integration.</alert>
+      <alert>Useful in continuous integration.</alert>
 
    - `options` allows you to pass in `html-validate` options that will be merged with the default configuration
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,10 +24,12 @@ export const defaultHtmlValidateConfig: ConfigData = {
 
 export interface ModuleOptions {
   usePrettier?: boolean
+  failOnError?: boolean
   options?: ConfigData
 }
 
 export const DEFAULTS: Required<ModuleOptions> = {
   usePrettier: false,
+  failOnError: false,
   options: defaultHtmlValidateConfig
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import consola from 'consola'
 import defu from 'defu'
 
 import { DEFAULTS, ModuleOptions } from './config'
-import { useChecker, useValidator } from './validator'
+import { useChecker, useValidator, failOnError as failIfError } from './validator'
 
 const CONFIG_KEY = 'htmlValidator'
 
@@ -14,7 +14,7 @@ const nuxtModule: Module<ModuleOptions> = function (moduleOptions) {
   )
 
   const providedOptions = defu(this.options[CONFIG_KEY] || {}, moduleOptions)
-  const { usePrettier, options } = defu(providedOptions, DEFAULTS)
+  const { usePrettier, failOnError, options } = defu(providedOptions, DEFAULTS)
   if (options && providedOptions.options && providedOptions.options.extends) {
     options.extends = providedOptions.options.extends
   }
@@ -24,6 +24,7 @@ const nuxtModule: Module<ModuleOptions> = function (moduleOptions) {
 
   this.nuxt.hook('render:route', (url: string, result: { html: string }) => checkHTML(url, result.html))
   this.nuxt.hook('generate:page', ({ path, html }: { path: string, html: string }) => checkHTML(path, html))
+  this.nuxt.hook('generate:done', () => failIfError(failOnError))
 }
 
 ;(nuxtModule as any).meta = { name: '@nuxtjs/html-validator' }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -6,6 +6,14 @@ const validators = new Map<ConfigData, HtmlValidate>()
 
 const defaultOptions = {}
 
+let hasError = false
+
+export const failOnError = (shouldFail : boolean) => {
+  if (shouldFail && hasError) {
+    throw new Error('html-validator found errors!')
+  }
+}
+
 export const useValidator = (options: ConfigData = defaultOptions) => {
   if (validators.has(options)) {
     return { validator: validators.get(options)! }
@@ -45,6 +53,8 @@ export const useChecker = (
       `No HTML validation errors found for ${chalk.bold(url)}`
     )
   }
+
+  hasError = true
 
   const formatter = couldFormat ? formatterFactory('codeframe') : formatterFactory('stylish')
 

--- a/test/checker.test.ts
+++ b/test/checker.test.ts
@@ -29,7 +29,7 @@ describe('useChecker', () => {
 
   it('works with a consola reporter', async () => {
     const mockValidator = jest.fn().mockImplementation(() => ({ valid: false, results: [] }))
-    const checker = useChecker({ validateString: mockValidator } as any)
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any)
 
     await checker('https://test.com/', '<a>Link</a>')
     expect(mockValidator).toHaveBeenCalled()
@@ -38,7 +38,7 @@ describe('useChecker', () => {
 
   it('calls the provided validator', async () => {
     const mockValidator = jest.fn().mockImplementation(() => ({ valid: true, results: [] }))
-    const checker = useChecker({ validateString: mockValidator } as any, false, mockReporter as any)
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, mockReporter as any)
 
     await checker('https://test.com/', '<a>Link</a>')
     expect(mockValidator).toHaveBeenCalled()
@@ -47,16 +47,24 @@ describe('useChecker', () => {
 
   it('prints an error message when invalid html is provided', async () => {
     const mockValidator = jest.fn().mockImplementation(() => ({ valid: false, results: [] }))
-    const checker = useChecker({ validateString: mockValidator } as any, false, mockReporter as any)
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, mockReporter as any)
 
     await checker('https://test.com/', '<a>Link</a>')
     expect(mockValidator).toHaveBeenCalled()
     expect(mockReporter.error).toHaveBeenCalled()
   })
 
+  it('records urls when invalid html is provided', async () => {
+    const mockValidator = jest.fn().mockImplementation(() => ({ valid: false, results: [] }))
+    const { checkHTML: checker, invalidPages } = useChecker({ validateString: mockValidator } as any, false, mockReporter as any)
+
+    await checker('https://test.com/', '<a>Link</a>')
+    expect(invalidPages).toContain('https://test.com/')
+  })
+
   it('ignores Vue-generated scoped data attributes', async () => {
     const mockValidator = jest.fn().mockImplementation(() => ({ valid: true, results: [] }))
-    const checker = useChecker({ validateString: mockValidator } as any, false, mockReporter as any)
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, false, mockReporter as any)
 
     await checker(
       'https://test.com/',
@@ -70,7 +78,7 @@ describe('useChecker', () => {
 
   it('formats HTML with prettier when asked to do so', async () => {
     const mockValidator = jest.fn().mockImplementation(() => ({ valid: false, results: [] }))
-    const checker = useChecker({ validateString: mockValidator } as any, true, mockReporter as any)
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, true, mockReporter as any)
 
     await checker('https://test.com/', '<a>Link</a>')
     expect(prettier.format).toHaveBeenCalledWith('<a>Link</a>', { parser: 'html' })
@@ -79,7 +87,7 @@ describe('useChecker', () => {
 
   it('falls back gracefully when prettier cannot format', async () => {
     const mockValidator = jest.fn().mockImplementation(() => ({ valid: false, results: [] }))
-    const checker = useChecker({ validateString: mockValidator } as any, true, mockReporter as any)
+    const { checkHTML: checker } = useChecker({ validateString: mockValidator } as any, true, mockReporter as any)
 
     await checker('https://test.com/', Symbol as any)
     expect(prettier.format).toHaveBeenCalledWith(Symbol, { parser: 'html' })


### PR DESCRIPTION
Add an option`failOnError` (false by default) to make the command ` nuxt generate` failing if an error is met. 

Useful in Continuous Integration